### PR TITLE
Fixed Spelling errors

### DIFF
--- a/Part 3/p3c06.tex
+++ b/Part 3/p3c06.tex
@@ -119,7 +119,7 @@ $SG$ means $S\wedge M = M$, so a Moore spectrum of type $G$ may be written $SG$.
 \begin{enumerate}
     \item There exists an exact sequence
     % TODO: that weird l again + not sure if that's a Z or \bZ
-    \[0\lra \pi_n(E)\otimes G \lra (EG)_n(X)\lra \mathrm{Tor}_1^\bZ \left(\pi_{n-1}(E)\right) \lra 0\]
+    \[0\lra \pi_n(E)\otimes G \lra \pi_n(EG) \lra \mathrm{Tor}_1^\bZ \left(\pi_{n-1}(E)\right) \lra 0\]
     (This need not split, e.g., take $E=\te{KO}, G=\bZ_2$.)
     \item More generally, there exists exact sequences
     \[0\lra E_n(X)\otimes G \lra (EG)_n(X)\lra \mathrm{Tor}_1^\bZ \left(E_{n-1}(X), G\right) \lra 0\]
@@ -184,7 +184,7 @@ and more generally,
 \end{proof}
 % TODO: I think the proof ended here but I'm not sure
 
-To pet the isomorphisms in the last case we assume either that $X$ is a finite spectrum or that $\alpha$ and $\beta$ run over finite sets, which we can arrange if $G$ is finitely generated. Now the cokernel and kernel of $i\otimes l$ are, according to the case
+To get the isomorphisms in the last case we assume either that $X$ is a finite spectrum or that $\alpha$ and $\beta$ run over finite sets, which we can arrange if $G$ is finitely generated. Now the cokernel and kernel of $i\otimes l$ are, according to the case
 \begin{align}
     G\otimes \pi_n(E) && \text{and} && \mathrm{Tor}_1^\bZ \left( G, \pi_n(E) \right) \nonumber \\
     G\otimes E_n(X) && \text{and} && \mathrm{Tor}_1^\bZ \left( G, E_n(X) \right) \nonumber \\
@@ -274,7 +274,7 @@ Now we give a checklist of the standard spectra corresponding to the usual gener
     \item $S$, the sphere spectrum. The corresponding homology and cohomology theories are stable homotopy and stable cohomotopy. With all due respect to anyone who is interested in them, the coefficient groups $\pi_n(S)$ are a mess. There is a lot of detailed information known about them, but I won't try to summarize it.
     \item $K$, the classical $\te{BU}$-spectrum. This is an $\Omega$- or $\Omega_0$-spectrum; each even term is space $\te{BU}$ or $\bZ\times \te{BU}$; each odd term is the space $\te{U}$.
     
-    The corresponding homology and cohomology theories are complex $K$-homology and $K$-cohomology. In fact it is rather easy to see that for a finite-dimensional CW-complex $X$, $[X, \bZ\times \te{BU}]$ agrees with the Atiyah-Hirzebruch definition of $K(X)$ or $\widetilde{K}(X)$ in terms of complex vector-bundles over $X$. (Here we have to take $\widetilde{K}(X)$ if $[X, \bZ\times \te{BU}]$ means homotopy classes of maps preserving the base-point, or $K(X)$ if we work without base-points.) This shows that our definition of $K^\ast(X)$ agrees with the Atiyah-Hirzebruch definition if $X$ is a finite-dimensional CW-complex. For infinite~dimensional complexes our $K^\ast(X)$ is the variant called ``representable K-theor'', i.e., we take $[X,\bZ\times \te{BU}]$ as the definition. 
+    The corresponding homology and cohomology theories are complex $K$-homology and $K$-cohomology. In fact it is rather easy to see that for a finite-dimensional CW-complex $X$, $[X, \bZ\times \te{BU}]$ agrees with the Atiyah-Hirzebruch definition of $K(X)$ or $\widetilde{K}(X)$ in terms of complex vector-bundles over $X$. (Here we have to take $\widetilde{K}(X)$ if $[X, \bZ\times \te{BU}]$ means homotopy classes of maps preserving the base-point, or $K(X)$ if we work without base-points.) This shows that our definition of $K^\ast(X)$ agrees with the Atiyah-Hirzebruch definition if $X$ is a finite-dimensional CW-complex. For infinite~dimensional complexes our $K^\ast(X)$ is the variant called ``representable K-theory'', i.e., we take $[X,\bZ\times \te{BU}]$ as the definition. 
     
     The coefficient groups are given by the Bott periodicity theorem:
     \[\pi_n(K) =
@@ -325,7 +325,7 @@ Now we give a checklist of the standard spectra corresponding to the usual gener
     \end{align}
     So the two summands into which $K\bZ[1/2]$ splits are actually copies of $\te{KO}\bZ[1/2]$, it follows that if you introduce a ring of coefficients containing $1/2$, $K$ cannot be distinguished from two copies of $\te{KO}$. Of course this is classical, by a more direct proof.
     \item Connective real $K$-theory. $\te{bo}$ \index{bo/Connective real $K$-theory} is a spectrum having a map $\te{bo}\lra \te{KO}$ with properties like those of $\te{bu}\lra K$
-    \item $\te{KSC}$, the self-conjugate $K$-theory \index{KSC/Self-conjugate $K$ theory} of Anderson and Green, The quickest way to say it is this. To each bundle $\xi$ we have its complex conjugate $\overline{\xi}$ which has the same underlying space but a new $C$-module structure on each fiber; the mew action of $z$ is the old action of $\overline{z}$. Stably, this is induced by a map $\bZ \times \te{BU} \vra{t} \bZ \times \te{BU}$. We can define a map of spectra $T\colon K\lra K$ which has components $t$ in dimensions divisible by $4$, and $-t$ in dimensions of the form $4r+2$. Now take $\te{KSC}$ to be the fiber of
+    \item $\te{KSC}$, the self-conjugate $K$-theory \index{KSC/Self-conjugate $K$ theory} of Anderson and Green, The quickest way to say it is this. To each bundle $\xi$ we have its complex conjugate $\overline{\xi}$ which has the same underlying space but a new $C$-module structure on each fiber; the new action of $z$ is the old action of $\overline{z}$. Stably, this is induced by a map $\bZ \times \te{BU} \vra{t} \bZ \times \te{BU}$. We can define a map of spectra $T\colon K\lra K$ which has components $t$ in dimensions divisible by $4$, and $-t$ in dimensions of the form $4r+2$. Now take $\te{KSC}$ to be the fiber of
     \[K\vra{1-\tau}K\]
     You can read its homotopy groups off from the exact sequence of this fibering: we have 
     \[\ialign{$\hfil#$&\quad$#$&&\quad$#$\hfil\cr
@@ -339,7 +339,7 @@ Now we give a checklist of the standard spectra corresponding to the usual gener
     \item $\te{MSO}$. The corresponding theories are oriented bordism and cobordism. We have\footnote{Adam's originally just had $\te{MSO}$ as the Eilenberg-Maclane spectrum, however this is only true after localizing at $2$.}
     \[\te{MSO}_{(2)}\simeq H \left( \pi_\ast(\te{MSO}_{(2)}) \right)\]
     $\pi_\ast(\te{MSO}_{(2)})$ is a direct sum of copies of $\bZ$ and $\bZ_2$. It is known but somewhat complicated to describe.
-    \item $\te{MU}$. The corresponding theories are complex bordism and cobordism. $\pi_\ast(\te{MU})$ is a polynomial algebra over $\bZ$ with generators of dimension $2,4,6,8\dots$ There is a very good map $\te{MU}\lra K$  due to Atiyah-Hirzebrach, Conner-Floyd \cite{atiyahhirzebruch}, \cite{connerfloyd}. The theories $\te{MU}_\ast$, $\te{MU}^\ast$ are powerful.
+    \item $\te{MU}$. The corresponding theories are complex bordism and cobordism. $\pi_\ast(\te{MU})$ is a polynomial algebra over $\bZ$ with generators of dimension $2,4,6,8\dots$ There is a very good map $\te{MU}\lra K$  due to Atiyah-Hirzebruch, Conner-Floyd \cite{atiyahhirzebruch}, \cite{connerfloyd}. The theories $\te{MU}_\ast$, $\te{MU}^\ast$ are powerful.
     \item $\te{MU}$ with coefficients. If one takes $\te{MU}\bZ_{(p)}$ , it splits as a sum of suspensions of similar spectra. A typical one is $\te{BP}$, the Brown-Peterson spectrum. $\pi_\ast(\te{BP})$ is a polynomial algebra over $\bZ_{(p)}$, on generators of dimension $2(p^f-1)$ for $f=1, 2, \dots$
     \item $\te{MSpin}$, $\te{MSU}$, $\te{MSp}$. $\pi_\ast(\te{MSpin})$ and $\pi_\ast(\te{MSU})$ are known but $\pi_\ast(\te{MSp})$ is not yet known. %add reference if changed
     \end{enumerate}
@@ -411,9 +411,9 @@ Now we give a checklist of the standard spectra corresponding to the usual gener
     \end{align}
     This gets my suspension isomorphism in a form convenient for later work, and makes the boundary and coboundary quite precise.
 
-Now we would like to assure ourselves that all the contents of Eilenberg-Steenrod, Chapter I, go through. But we can also put the question in this form: is there anything in Ellenberg-Steenrod Chapter I which can't be derived from our constructions? The grand conclusion should be that the homology groups of sphere are the right thing, and we already know that
+Now we would like to assure ourselves that all the contents of Eilenberg-Steenrod, Chapter I, go through. But we can also put the question in this form: is there anything in Eilenberg-Steenrod Chapter I which can't be derived from our constructions? The grand conclusion should be that the homology groups of spheres are the right thing, and we already know that
 \begin{align}
-    \widetilde{E} &= [S^n, E]_r \nonumber \\
+    \widetilde{E}_r( S^n) &= [S^n, E]_r \nonumber \\
     &\cong [S^0, E]_{r-n} \nonumber \\
     &\cong \pi_{r-n}(E) \nonumber
 \end{align}
@@ -510,7 +510,7 @@ Here $g'$ is induced from $g$, etc. If the original diagram is only homotopy-com
 
 This is sometimes known as Verdier's axiom. The proof is elementary. One way to say it is this: you can assume without loss of generality that $f$ and $g$ are inclusions, and then I have told you everything necessary already. Since the constructions are elementary, they commute with suspensions on the right and carry over to spectra. So the corresponding lemma is true for spectra. In a fully Bourbakized treatment this lemma would go in Section \ref{sec:p3ch03}. 
 
-The next thing we would like to know is the Mayer-Vietoris sequence, This needs no special proof either. Suppose that we have a CW-complex which is the union of two subcomplexes $U$ and $V$. We wish to know the relationship of $E_\ast(U\cup V)$, $E_\ast(U)$, $E_\ast(V)$, $E_\ast(U\cap V)$. We may replace these by $E_\ast(\Sigma (U\cup V)^+)$, etc. So we take $\Sigma (U\cap V)^+$ and $\Sigma (U^+\vee V^+)$ and make a map from one to the other by taking $i_1$-$i_2$, where $i_1\colon (U\cap V)^+\lra U^+$ and $i_2\colon (U\cap V)^+\lra V^+$ are the inclusions. Now let me form the cofiber sequence
+The next thing we would like to know is the Mayer-Vietoris sequence. This needs no special proof either. Suppose that we have a CW-complex which is the union of two subcomplexes $U$ and $V$. We wish to know the relationship of $E_\ast(U\cup V)$, $E_\ast(U)$, $E_\ast(V)$, $E_\ast(U\cap V)$. We may replace these by $E_\ast(\Sigma (U\cup V)^+)$, etc. So we take $\Sigma (U\cap V)^+$ and $\Sigma (U^+\vee V^+)$ and make a map from one to the other by taking $i_1$-$i_2$, where $i_1\colon (U\cap V)^+\lra U^+$ and $i_2\colon (U\cap V)^+\lra V^+$ are the inclusions. Now let me form the cofiber sequence
 \[\Sigma (U\cap V)^+ \lra \Sigma (U^+\vee V^+) \lra \Sigma (U^+\vee V^+)\cup_{i_1-i_2} C\Sigma (U\cap V)^+ \lra \Sigma^2(U\cap V)^+\lra\dots\]
 The third term is the same as
 \[\Sigma U^+\vee \Sigma V^+\cup \te{Cyl}(\Sigma(U\cap V)^+)\]


### PR DESCRIPTION
Fixed term in SES on page 218 / line 122
Spelling Error on page 219 / line 187 “pet” to “get” Spelling Error on page 222 / line 277 “K-theor” to “K-theory” Spelling Error on page 225 / line 328 “mew” to “new” Spelling Error on page 226 / line 342 “mew” to “new” Spelling Error on page 228 / line 414 “Ellenberg” to “Eilenberg” and “sphere” to “spheres Error in Equation on page 229 / line 416 “\widetilde{E}” to “\widetilde{E}_r( S^n)” Comma to dot on page 231 / line 513