### PR TITLE
Fix a typo in formulation of Atiyah-Hirzebruch spectral sequence

### DIFF
--- a/Part 3/p3c07.tex
+++ b/Part 3/p3c07.tex
@@ -15,7 +15,7 @@ For each CW-spectrum $F$ there exist spectral sequences
 \begin{center}
     \begin{tikzcd}[column sep=large]
     H_p(X;\pi_q(F))\arrow[r,Rightarrow,"p"]&F_{p+q}(X)\\
-    H^p(X;\pi_q(F))\arrow[r,Rightarrow,"p"]&F^{p+q}(X).
+    H^p(X;\pi_{-q}(F))\arrow[r,Rightarrow,"p"]&F^{p+q}(X).
     \end{tikzcd}
 \end{center}
 \end{theorem*}


### PR DESCRIPTION
Fix a typo in Adams book: In cohomology theory of a point, the subscript of homotopy groups are reversed as explained in p.157.